### PR TITLE
PDF Build 2.0 and included PDF.zip download link on README.md

### DIFF
--- a/.github/workflows/pdf-build.yml
+++ b/.github/workflows/pdf-build.yml
@@ -31,8 +31,7 @@ jobs:
           npm install --save-dev @marp-team/marp-cli markdown-pdf
       - name: Build PDFs
         run: |
-          for input in *.md */*.md;
-          do
+          for input in *.md */*.md; do
             output=`echo -n $input | sed -e 's/\.md$/.pdf/g'`
             echo "Input: $input, output $output";
             if [[ $(grep -l 'marp: true' $input) ]];

--- a/.github/workflows/pdf-build.yml
+++ b/.github/workflows/pdf-build.yml
@@ -23,23 +23,22 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-
+          key: "${{ runner.os }}-node-"
           restore-keys: |
-            ${{ runner.os }}-node-
+            "${{ runner.os }}-node-"
       - name: Install marp
         run: |
           npm install --save-dev @marp-team/marp-cli markdown-pdf
       - name: Build PDFs
         run: |
           for input in *.md */*.md; do
-            output=`echo -n $input | sed -e 's/\.md$/.pdf/g'`
-            echo "Input: $input, output $output";
-            if [[ $(grep -l 'marp: true' $input) ]];
-            then
+            output="${input%.md}.pdf"
+            echo "Input: $input, output $output"
+            if [[ "$(grep -l 'marp: true' "$input")" ]]; then
               npx marp --allow-local-files "$input" -o "$output"
             else
               npx markdown-pdf "$input" -o "$output"
-            fi;
+            fi
             zip -g PDF.zip "$output"
           done
       - name: Set GitHub auth token

--- a/.github/workflows/pdf-build.yml
+++ b/.github/workflows/pdf-build.yml
@@ -6,6 +6,7 @@ on:
       - main
 jobs:
   Build:
+    if: github.repository == 'jmunixusers/presentations'
     name: Build PDF release bundle
     runs-on: ubuntu-18.04
     steps:
@@ -27,18 +28,21 @@ jobs:
             ${{ runner.os }}-node-
       - name: Install marp
         run: |
-          npm install --save-dev @marp-team/marp-cli
+          npm install --save-dev @marp-team/marp-cli markdown-pdf
       - name: Build PDFs
         run: |
-          for input in `grep -l 'marp: true' *.md */*.md`
+          for input in *.md */*.md;
           do
-            output=`echo -n $input | sed -e 's/.md$//g'`
-            echo "$output.pdf"
-            npx marp --allow-local-files "$input" -o "$output.pdf"
+            output=`echo -n $input | sed -e 's/\.md$/.pdf/g'`
+            echo "Input: $input, output $output";
+            if [[ $(grep -l 'marp: true' $input) ]];
+            then
+              npx marp --allow-local-files "$input" -o "$output"
+            else
+              npx markdown-pdf "$input" -o "$output"
+            fi;
+            zip -g PDF.zip "$output"
           done
-      - name: Zip PDFs
-        run: |
-          find . -name "*pdf" -exec zip -g PDF.zip {} \;
       - name: Set GitHub auth token
         run: |
           gh config set -h github.com oauth_token "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JMU UUG Presentations
 This is a collection of presentation notes from previous UUG meetings.
 
-For slides rendered to PDF or presentation notes for offline reading, download the [PDF bundle](https://urldefense.proofpoint.com/v2/url?u=https-3A__github.com_jmunixusers_presentations_releases_download_presentation-2Dlatest_PDF.zip&d=DwIFAg&c=eLbWYnpnzycBCgmb7vCI4uqNEB9RSjOdn_5nBEmmeq0&r=mViWwgbSiVLhCGiO9Z8qEZQsAou42O8YdImT6H2vetA&m=MuxyRaq95bpbbcGIEV3VK-OUYUGxMIfVGdhvNa9H-Ps&s=QhkzRMyyK1t92-aRWvb2d3HoWoLYeqNr8vd9rqsn4mI&e=).
+For slides rendered to PDF or presentation notes for offline reading, download the [PDF bundle](https://github.com/jmunixusers/presentations/releases/download/presentation-latest/PDF.zip).
 
 ## Special Events
 * [InstallFest](InstallFest.md)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # JMU UUG Presentations
 This is a collection of presentation notes from previous UUG meetings.
+
 For slides rendered to PDF or presentation notes for offline reading, download the [PDF bundle](https://urldefense.proofpoint.com/v2/url?u=https-3A__github.com_jmunixusers_presentations_releases_download_presentation-2Dlatest_PDF.zip&d=DwIFAg&c=eLbWYnpnzycBCgmb7vCI4uqNEB9RSjOdn_5nBEmmeq0&r=mViWwgbSiVLhCGiO9Z8qEZQsAou42O8YdImT6H2vetA&m=MuxyRaq95bpbbcGIEV3VK-OUYUGxMIfVGdhvNa9H-Ps&s=QhkzRMyyK1t92-aRWvb2d3HoWoLYeqNr8vd9rqsn4mI&e=).
 
 ## Special Events

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # JMU UUG Presentations
 This is a collection of presentation notes from previous UUG meetings.
+For slides rendered to PDF or presentation notes for offline reading, download the [PDF bundle](https://urldefense.proofpoint.com/v2/url?u=https-3A__github.com_jmunixusers_presentations_releases_download_presentation-2Dlatest_PDF.zip&d=DwIFAg&c=eLbWYnpnzycBCgmb7vCI4uqNEB9RSjOdn_5nBEmmeq0&r=mViWwgbSiVLhCGiO9Z8qEZQsAou42O8YdImT6H2vetA&m=MuxyRaq95bpbbcGIEV3VK-OUYUGxMIfVGdhvNa9H-Ps&s=QhkzRMyyK1t92-aRWvb2d3HoWoLYeqNr8vd9rqsn4mI&e=).
 
 ## Special Events
 * [InstallFest](InstallFest.md)


### PR DESCRIPTION
PDF 2.0 changes include:
- Only running on the UUG repository, not forks
- Render all markdowns to PDF, not just marp slides
- Moving the zip command inside the loop