### PR TITLE
Add markdown linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,24 @@
+---
+name: Lint Presentations
+
+on:
+  pull_request
+
+jobs:
+  build:
+    name: Lint Presentations
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+      - name: Install markdownlint
+        run: |
+          npm --save-dev install markdownlint markdownlint-cli
+      - name: Lint markdown files
+        run: |
+          npx markdownlint *md */*.md

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,10 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD022": false,
+  "MD024": false,
+  "MD025": false,
+  "MD026": false,
+  "MD041": false,
+  "MD045": false
+}


### PR DESCRIPTION
Attempting to add a markdown linter on PRs here. I've taken a pretty light touch approach to try to gently get us to a common baseline, but that's certainly open to revision later. Having this configuration in the repository will also help when editing via VS Code, since it uses the same file.

I'm intending to leave this PR open and rebase it as presentations are linted, giving an opportunity to some who are missing last minute PRs. If you've completed Hacktoberfest, please leave this alone for now.