### PR TITLE
Enable accessibility

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -6,7 +6,5 @@
   "MD025": false,
   "MD026": false,
   "MD033": false,
-  "MD041": false,
-  "MD045": false,
-  "MD059": false
+  "MD041": false
 }

--- a/BuildAVM/index.md
+++ b/BuildAVM/index.md
@@ -93,7 +93,7 @@ marp: true
 
 # VM Skeleton - too many buttons to get right
 
-![](image01.png)
+![VirtualBox VM configuration screenshot](image01.png)
 
 ---
 
@@ -346,4 +346,4 @@ jgrasp:
 
 # Contributing to the project
 
-![](image08.png)
+![GitHub project page screenshot](image08.png)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For slides rendered to PDF or presentation notes for offline reading, download t
 - [Starlink](starlink/index.md)
 - [Systemd Security](Systemd-security.md)
 - [TLS](TLS.md)
-- [zstd](zstd.md)
+- [zstd](zstd/index.md)
 
 ## Virtual Machine
 

--- a/Scripting.md
+++ b/Scripting.md
@@ -94,8 +94,7 @@ The `[ ... ]` command is an alias for `test` (`/bin/test`) and returns either 0
 `[[ ... ]]` is a superset of the `test` functionality, with a few added
 functions, though this functionality is not POSIX standard and therefore varies
 based on the system. I will be working based on `bash`'s implementation of `[[`
-(found
-[here](https://www.gnu.org/software/bash/manual/html_node/Conditional-Constructs.html#index-_005b_005b)).
+([documented here](https://www.gnu.org/software/bash/manual/html_node/Conditional-Constructs.html#index-_005b_005b)).
 But your results may vary if using something else.
 
 Some useful operators are:

--- a/containers/index.md
+++ b/containers/index.md
@@ -69,7 +69,7 @@ We'll get to that later
   - WSL2 is now virtualized
 
 ---
-![](image4.png)
+![LWN article 780364 screenshot](image4.png)
 
 [https://lwn.net/Articles/780364/](https://lwn.net/Articles/780364/)
 

--- a/elastic/index.md
+++ b/elastic/index.md
@@ -16,17 +16,17 @@ What is Elastic?
 
 # Along came Beats to the ELK family, giving us the ELK-B(ee)
 
-![](image02.png)
+![Elastic ELK-B mascot logo](image02.png)
 
 ---
 
 # Elastic Universe circa 2018
 
-![](image03.png)
+![ElasticStack architecture diagram](image03.png)
 
 ---
 
-![bg](image04.png)
+![ElasticStack architecture and deployment diagram](image04.png)
 
 ---
 

--- a/homelab-storage/index.md
+++ b/homelab-storage/index.md
@@ -367,8 +367,8 @@ borg compact
 
 <div class="right-col">
 
-![](vorta.png)
-![](pika.png)
+![Vorta screenshot](vorta.png)
+![Pika screenshot](pika.png)
 
 </div>
 

--- a/starlink/index.md
+++ b/starlink/index.md
@@ -16,7 +16,7 @@ Mitch Feigenbaum - <https://mitchf.me>
 
 ---
 
-![](woods.jpg)
+![Cabin woods view photo](woods.jpg)
 
 ---
 
@@ -45,11 +45,11 @@ Mitch Feigenbaum - <https://mitchf.me>
 
 ---
 
-![bg contain](starlink_eth.jpg)
+![bg contain Starlink architecture diagram](starlink_eth.jpg)
 
 ---
 
-![](eero.jpg)
+![Eero device photo](eero.jpg)
 
 ---
 

--- a/zstd/index.md
+++ b/zstd/index.md
@@ -43,18 +43,18 @@ The bestest compression ever
 
 ---
 # Some benchmarks
-![](zstd/benchmark1.png)
+![zstd benchmark diagram](zstd/benchmark1.png)
 
 <https://engineering.fb.com/2016/08/31/core-data/smaller-and-faster-data-compression-with-zstandard/>
 
 ---
 # More benchmark
-![](zstd/benchmark2.png)
+![zstd benchmark diagram](zstd/benchmark2.png)
 
 <https://engineering.fb.com/2016/08/31/core-data/smaller-and-faster-data-compression-with-zstandard/>
 
 ---
 # One more for good luck
-![](zstd/benchmark3.png)
+![zstd benchmark diagram](zstd/benchmark3.png)
 
 <http://facebook.github.io/zstd/>


### PR DESCRIPTION
Clean up a few missing alt-text items so we can re-enable linter rules, and try to do better going forward.

Closes #126 